### PR TITLE
Slightly better goto definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nimble.develop
 nimble.paths
+nimbledeps

--- a/src/nimsight.nim
+++ b/src/nimsight.nim
@@ -116,7 +116,7 @@ lsp.listen(symbolDefinition) do (h: RequestHandle, params: TextDocumentPositionP
         if symbol.name.nimIdentNormalize() == targetName:
           return some Location(
             uri: params.textDocument.uri,
-            range: symbol.range
+            range: symbol.selectionRange
           )
 
 lsp.listen(documentSymbols) do (

--- a/src/nimsight.nim
+++ b/src/nimsight.nim
@@ -106,11 +106,11 @@ lsp.listen(symbolDefinition) do (h: RequestHandle, params: TextDocumentPositionP
 
       # Check if the node is an identifier
       let foundNode = document[nodeUnder.unsafeGet()]
-      debug $foundNode.kind
       if foundNode.kind != nkIdent: return none(Location)
 
       let targetName = foundNode.strVal.nimIdentNormalize()
 
+      # Now search the outline, and return the first match
       let outline = document.getPtr(NodeIdx(0)).outLineDocument()
       for symbol in outline:
         if symbol.name.nimIdentNormalize() == targetName:

--- a/src/nimsight.nim
+++ b/src/nimsight.nim
@@ -96,17 +96,28 @@ lsp.listen(codeAction) do (h: RequestHandle, params: CodeActionParams) -> seq[Co
       return getCodeActions(h, fileStore, params)
 
 lsp.listen(symbolDefinition) do (h: RequestHandle, params: TextDocumentPositionParams) -> Option[Location] {.gcsafe.}:
-  let usages = h.findUsages(params.textDocument.uri, params.position)
-  if usages.isSome():
-    let usages = usages.unsafeGet()
-    return some Location(
-      uri: DocumentURI("file://" & usages.def[0]),
-      range: Range(
-        start: usages.def[1],
-        `end`: Position(line: usages.def[1].line, character: usages.def[1].character + 1)
-      )
-    )
+  # See if we can find a unique symbol in the outline
+  writeWith filesLock:
+    {.gcsafe.}:
+      # Build AST and find the node the user is pointing at
+      let document = fileStore.parseFile(params.textDocument.uri).ast
+      let nodeUnder = document[].findNode(params.position)
+      if nodeUnder.isNone(): return none(Location)
 
+      # Check if the node is an identifier
+      let foundNode = document[nodeUnder.unsafeGet()]
+      debug $foundNode.kind
+      if foundNode.kind != nkIdent: return none(Location)
+
+      let targetName = foundNode.strVal.nimIdentNormalize()
+
+      let outline = document.getPtr(NodeIdx(0)).outLineDocument()
+      for symbol in outline:
+        if symbol.name.nimIdentNormalize() == targetName:
+          return some Location(
+            uri: params.textDocument.uri,
+            range: symbol.range
+          )
 
 lsp.listen(documentSymbols) do (
   h: RequestHandle,

--- a/src/nimsight/customast.nim
+++ b/src/nimsight/customast.nim
@@ -11,6 +11,8 @@ import sdk/types
 
 import utils/ast
 
+export nodekinds
+
 type
   NodeIdx* = uint32
     ## Index into the tree

--- a/src/nimsight/nimCheck.nim
+++ b/src/nimsight/nimCheck.nim
@@ -173,26 +173,6 @@ proc execProcess*(handle: RequestHandle, cmd: string, args: openArray[string], i
     raiseCancelled()
   return (process.outputStream().readAll(), process.peekExitCode())
 
-proc findUsages*(handle: RequestHandle, file: DocumentURI, pos: Position): Option[SymbolUsage] =
-  ## Uses --defusages to find symbol usage/defintion
-  ## Uses IC so isn't braindead slow which is cool, but zero clue
-  ## what stability is like lol
-  # Use refc to get around https://github.com/nim-lang/Nim/issues/22205
-  let (outp, status) = handle.execProcess("nim", @["check", "--ic:on", "--mm:refc", fmt"--defusages:{file},{pos.line + 1},{pos.character + 1}"] & ourOptions & $file.path)
-  if status == QuitFailure: return
-  var s = SymbolUsage()
-  for lineStr in outp.splitLines():
-    var
-      file = ""
-      line = -1
-      col = -1
-    # TODO: Fix navigator.nim so that the RHS of identDefs isn't considered a decl
-    if lineStr.scanf("def$s$+($i, $i)", file, line, col):
-      s.def = (file, initPos(line, col))
-    elif lineStr.scanf("usage$s$+($i, $i)", file, line, col):
-      s.usages &= (file, initPos(line, col))
-  return some s
-
 proc getErrors*(handle: RequestHandle, file: NimFile, x: DocumentUri): seq[ParsedError] {.gcsafe.} =
   ## Parses errors from `nim check` into a more structured form
   # See if we can get errors from the cache

--- a/src/nimsight/nimCheck.nim
+++ b/src/nimsight/nimCheck.nim
@@ -1,5 +1,5 @@
 ## Utils for working with Nim check
-import std/[osproc, strformat, strscans, strutils, options, sugar, os, streams, paths, logging]
+import std/[osproc, strformat, options, sugar, os, streams, paths, logging]
 
 import sdk/[types, hooks, server, params]
 

--- a/src/nimsight/sdk/server.nim
+++ b/src/nimsight/sdk/server.nim
@@ -358,6 +358,7 @@ proc initServer*(name: string, version = NimblePkgVersion): Server =
           openClose: true,
           change: Full
         )),
+        definitionProvider: true,
         selectionRangeProvider: true
       ),
       serverInfo: ServerInfo(

--- a/src/nimsight/sdk/types.nim
+++ b/src/nimsight/sdk/types.nim
@@ -401,6 +401,7 @@ type
     documentSymbolProvider*: Union[(bool, DocumentSymbolOptions)]
     textDocumentSync*: Union[(bool, TextDocumentSyncOptions)]
     selectionRangeProvider*: bool
+    definitionProvider*: bool
 
   ClientCapabilities* = object
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -150,6 +150,7 @@ register_cmd("Def", function (opts)
   vim.lsp.buf_request_all(0, "textDocument/definition", args, function (result)
     local range = result[1].result.range
     println(string.format("%s:%s %s:%s", range.start.line, range.start.character, range["end"].line, range["end"].character))
+    coroutine.resume(cmds, "textDocument/definition")
   end)
 end, { })
 

--- a/tests/config.lua
+++ b/tests/config.lua
@@ -144,6 +144,15 @@ register_cmd("Diag", function (opts)
   end
 end, { })
 
+-- Prints the location the code will jump to
+register_cmd("Def", function (opts)
+  local args = vim.lsp.util.make_position_params()
+  vim.lsp.buf_request_all(0, "textDocument/definition", args, function (result)
+    local range = result[1].result.range
+    println(string.format("%s:%s %s:%s", range.start.line, range.start.character, range["end"].line, range["end"].character))
+  end)
+end, { })
+
 -- Applies a code action
 register_cmd("CodeAction", function (opts)
   local pos = vim.api.nvim_win_get_cursor(0)

--- a/tests/scripts/findDefinition.nim
+++ b/tests/scripts/findDefinition.nim
@@ -1,0 +1,5 @@
+
+proc hello() = discard
+
+hello() #[
+  ^ :Def ]#

--- a/tests/testFull.nim
+++ b/tests/testFull.nim
@@ -139,6 +139,10 @@ test "Shutdown":
   let output = nvimTest("shutdown")
   check "quit with exit code 1" notin output
 
+test "Go to definition":
+  let output = nvimTest("findDefinition")
+  check "1:6 1:10" in output
+
 suite "Nimscript":
   test "Nimble file loads without error":
     let output = nvimTest("nimble.nimble")

--- a/tests/testFull.nim
+++ b/tests/testFull.nim
@@ -141,7 +141,7 @@ test "Shutdown":
 
 test "Go to definition":
   let output = nvimTest("findDefinition")
-  check "1:6 1:10" in output
+  check "1:5 1:10" in output
 
 suite "Nimscript":
   test "Nimble file loads without error":


### PR DESCRIPTION
I found the old goto definition didn't work a lot (In fairness, it turns out I forgot to enable it) and would usually fail since Nim's IC doesn't really work. Instead moved to a system that uses the symbols parsed in the current document. While this won't work cross document or in local scopes it does do it a bit more of the time and can be improved